### PR TITLE
Fixes broken NPM require

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flexibility",
   "version": "0.2.3",
   "description": "Use flexbox while supporting older Internet Explorers",
-  "main": "index.js",
+  "main": "dist/flexibility.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/10up/flexibility.git"
@@ -47,6 +47,7 @@
   "scripts": {
   	"build": "gulp",
     "lint": "eslint . --ignore-path .eslintignore",
+    "prepublish": "npm run build",
     "test": "npm run lint"
   },
   "dependencies": {},


### PR DESCRIPTION
The main file wasn't pointing at the entry point script (`index.js` doesn't exist), causing `require('flexibility')` to fail. I also added a `prepublish` script entry to automatically build the project on `npm publish`.

The `demos` and `lib` directories don't need to be pushed to NPM, maybe consider adding them to `.npmignore`?